### PR TITLE
Allow using hashes for file names through the user interface/web page

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - .
 ignoredBuiltDependencies:
   - svelte-preprocess
 onlyBuiltDependencies:

--- a/src/lib/graphs/Graph.svelte
+++ b/src/lib/graphs/Graph.svelte
@@ -1023,7 +1023,10 @@ onMount(async () => {
     if (node.type === "species") {
       let data: string;
       if (xyzFiles) {
-        const file = xyzFiles.get(node.name + ".xyz");
+        const filename = useHash
+          ? `${node.hash}.xyz`
+          : `${node.name}.xyz`;
+        const file = xyzFiles.get(filename);
         if (!file) {
           return;
         }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -124,13 +124,27 @@ async function loadGraph(graphName: string) {
             </div>
             <div class="center">
                 <label for="elementHider">Don't visualize cu (optional)</label>
-                    <input 
-                        type="checkbox" 
+                    <input
+                        type="checkbox"
                         name="elementHider"
-                        on:change={(event) => { 
-                            hideCu = event.target.checked; 
-                        }} 
+                        on:change={(event) => {
+                            hideCu = event.target.checked;
+                        }}
                     />
+            </div>
+            <div
+                class="center"
+                title="Look up 3D structures by each species'/reaction's 'hash' attribute instead of its name/SMILES. Use this if your identifiers contain characters that aren't valid filenames."
+            >
+                <label for="useHash">Use hash for XYZ lookup (optional)</label>
+                <input
+                    type="checkbox"
+                    id="useHash"
+                    name="useHash"
+                    on:change={(event) => {
+                        useHash = event.target.checked;
+                    }}
+                />
             </div>
         </div>
         <div>


### PR DESCRIPTION
**disclaimer: Ich habe Claude für diese Änderungen benutzt, weil ich mich nicht mit TypeScript auskenne**

Beim Spielen mit Autograph ist mir immer wieder auf die Füße gefallen, dass SMILES oder InChIs, wenn man sie als Key nutzen will, keine validen Dateinamen sind. Da die Funktionalität andere Dateinamen zu nutzen bereits über die useHash Variable implementiert war, habe ich (bzw. Claude) hier einfach das user interface um eine entsprechende Checkbox erweitert.

Ich habe das ganze bei mir lokal getestet und es funktioniert soweit.

Zu der Änderung in `pnpm-workspace.yaml`: Lt. Claude ist das Feld `packages:`  seit version 9.5+ von pnpm verpflichtend, weshalb ich es hier einfach mal hinzugefügt habe.

Grüße aus Aachen
Florian